### PR TITLE
fix: resolve Node Sass binding issues in Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
-  # Build command
-  command = "npm run build:production"
+  # Build command with sass rebuild to fix binding issues
+  command = "npm ci && npm rebuild && npm run build:production"
 
   # Output directory
   publish = "dist"
@@ -10,6 +10,7 @@
     NODE_ENV = "production"
     NODE_VERSION = "18.20.0"
     NPM_FLAGS = "--production=false"
+    PYTHON = "python3"
     SECRETS_SCAN_OMIT_PATHS = "dist/**"
 
 [build.processing]
@@ -60,34 +61,34 @@
 
 # Branch-specific build settings
 [context.production]
-  command = "npm run build:production"
+  command = "npm ci && npm rebuild && npm run build:production"
   [context.production.environment]
     NODE_ENV = "production"
     VITE_ENABLE_DEBUG_LOGGING = "false"
     VITE_APP_NAME = "HolistiQ"
 
 [context.deploy-preview]
-  command = "npm run build:production"
+  command = "npm ci && npm rebuild && npm run build:production"
   [context.deploy-preview.environment]
     NODE_ENV = "development"
     VITE_ENABLE_DEBUG_LOGGING = "true"
 
 [context.branch-deploy]
-  command = "npm run build:production"
+  command = "npm ci && npm rebuild && npm run build:production"
   [context.branch-deploy.environment]
     NODE_ENV = "development"
     VITE_ENABLE_DEBUG_LOGGING = "true"
 
 # Specific branch configurations
 [context.develop]
-  command = "npm run build:production"
+  command = "npm ci && npm rebuild && npm run build:production"
   [context.develop.environment]
     NODE_ENV = "development"
     VITE_ENABLE_DEBUG_LOGGING = "true"
     VITE_APP_NAME = "HolistiQ Staging"
 
 [context.main]
-  command = "npm run build:production"
+  command = "npm ci && npm rebuild && npm run build:production"
   [context.main.environment]
     NODE_ENV = "production"
     VITE_ENABLE_DEBUG_LOGGING = "false"


### PR DESCRIPTION
- Add npm rebuild to build commands to fix sass binding errors
- Use npm ci for clean installs in Netlify environment
- Add PYTHON=python3 environment variable for native dependencies
- Apply fix to all build contexts (production, develop, deploy-preview)

This should resolve the 'Node Sass could not find a binding' error that occurs when sass dependencies have mismatched bindings for the build environment.